### PR TITLE
Fix auto-upgrade for apt

### DIFF
--- a/docs/packages.md
+++ b/docs/packages.md
@@ -531,7 +531,6 @@ through this role, You have to do it yourself.
 Supported package managers at this time :
 
 - `apt` (Debian like)
-- `dnf` (RedHat like version 8 or upper)
 
 Static package lists
 --------------------

--- a/tasks/package-managers/apt/unattended-upgrades.yml
+++ b/tasks/package-managers/apt/unattended-upgrades.yml
@@ -9,7 +9,6 @@
         state: stopped
 
     - name: APT - Unattended upgrades - Configuration
-      when: system_packages_upgrade_unattended
       ansible.builtin.template:
         src: apt/apt.conf.d/20auto-upgrades.j2
         dest: /etc/apt/apt.conf.d/20auto-upgrades

--- a/templates/apt/apt.conf.d/20auto-upgrades.j2
+++ b/templates/apt/apt.conf.d/20auto-upgrades.j2
@@ -1,4 +1,4 @@
 # {{ ansible_managed }}
 
-APT::Periodic::Update-Package-Lists "1";
-APT::Periodic::Unattended-Upgrade "1";
+APT::Periodic::Update-Package-Lists "{{ system_packages_upgrade_unattended | int }}";
+APT::Periodic::Unattended-Upgrade "{{ system_packages_upgrade_unattended | int }}";


### PR DESCRIPTION
## Description

* Copy `20auto-upgrades` file in all cases ( when `system_packages_upgrade_unattended` variable is true or false)
* Enable or disable auto-upgrades with `system_packages_upgrade_unattended` variable

## How to test

With molecule:
```
molecule test -p bookworm --destroy=never
```

Login to instance:
```
molecule login -h bookworm
```

### When system_packages_upgrade_unattended variable is false

Run the following command in the instance:
```
sudo systemctl restart apt-daily-upgrade.service
```

Output:
```
bookworm systemd[1]: Starting apt-daily-upgrade.service - Daily apt upgrade and clean activities...
bookworm systemd[1]: apt-daily-upgrade.service: Deactivated successfully.
bookworm systemd[1]: Finished apt-daily-upgrade.service - Daily apt upgrade and clean activities.
```
Nothing happens

### When system_packages_upgrade_unattended variable is true

Run the following command in the instance:
```
sudo systemctl restart apt-daily-upgrade.service
```

Output:
```
Oct 15 19:44:56 bookworm systemd[1]: apt-daily-upgrade.service: Consumed 39.215s CPU time.
```

Logs available in /var/log/unattended-upgrades/ 